### PR TITLE
Check for missing trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generic interface for file path expansion, PR #20. [@benkrikler](https://github.com/benkrikler)
 - Add option to ignore empty files, issue #5. [@benkrikler](https://github.com/benkrikler)
+- Report files with missing trees, issue #16, PR #24. [@benkrikler](https://github.com/benkrikler)
 
 ### Changed
 - Switch README to restructured text and update setup.py, PR 23.

--- a/fast_curator/__main__.py
+++ b/fast_curator/__main__.py
@@ -28,6 +28,10 @@ def arg_parser_write():
     parser.add_argument("--no-empty-files", default=False, action="store_true",
                         help="Don't include files that contain no events"
                         )
+    parser.add_argument("--allow-missing-tree", dest="confirm_tree",
+                        action="store_false", default=True,
+                        help="Allow files that don't contain the named tree in"
+                        )
 
     def split_meta(arg):
         if "=" not in arg:
@@ -48,6 +52,7 @@ def main_write(args=None):
     dataset = write.prepare_file_list(files=args.files, dataset=args.dataset,
                                       expand_files=args.query_type,
                                       no_empty_files=args.no_empty_files,
+                                      confirm_tree=args.confirm_tree,
                                       eventtype=args.eventtype, tree_name=args.tree_name)
     write.add_meta(dataset, args.meta)
     for user_func in args.user:

--- a/fast_curator/catalogues/__init__.py
+++ b/fast_curator/catalogues/__init__.py
@@ -63,7 +63,6 @@ def check_entries_uproot(files, tree, no_empty, confirm_tree=True):
     return full_list, n_entries
 
 
-
 known_expanders = dict(xrootd=XrootdExpander,
                        local=LocalGlobExpander,
                        )

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -14,7 +14,7 @@ __all__ = ["known_expanders", "prepare_file_list", "write_yaml",
 
 
 def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd",
-                      absolute_paths=True, no_empty_files=True):
+                      absolute_paths=True, no_empty_files=True, confirm_tree=True):
     """
     Expands all globs in the file lists and creates a dataframe similar to those from a DAS query
     """
@@ -24,7 +24,9 @@ def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd
     full_list = expand_files.expand_file_list(files)
     if absolute_paths:
         full_list = [os.path.realpath(f) if ':' not in f else f for f in full_list]
-    full_list, numentries = expand_files.check_entries(full_list, tree_name, no_empty=no_empty_files)
+    full_list, numentries = expand_files.check_entries(full_list, tree_name,
+                                                       no_empty=no_empty_files,
+                                                       confirm_tree=confirm_tree)
 
     data = {}
     data["eventtype"] = eventtype


### PR DESCRIPTION
Implements #16.  Adds the command line option `--allow-missing-tree` which disables the new check.