### PR TITLE
Add support for multiple input trees in each file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for handling mulitple input trees in each file, PR #28
 
 ### Changed
 

--- a/fast_curator/__main__.py
+++ b/fast_curator/__main__.py
@@ -15,7 +15,7 @@ def arg_parser_write():
                         help="Specify if this dataset contains simulated data")
     parser.add_argument("--data", dest="eventtype", action="store_const", const="data",
                         help="Specify if this dataset contains real data")
-    parser.add_argument("-t", "--tree-name", default="Events", type=str,
+    parser.add_argument("-t", "--tree-name", default=[], type=str, action="append",
                         help="Provide the name of the tree in the input files to calculate number of events, etc")
     parser.add_argument("-u", "--user", default=[], type=str, action="append",
                         help="Add a user function to extend the dataset dictionary,"
@@ -48,6 +48,8 @@ def arg_parser_write():
 
 def main_write(args=None):
     args = arg_parser_write().parse_args(args=args)
+    if not args.tree_name:
+        args.tree_name = ["Events"]
 
     dataset = write.prepare_file_list(files=args.files, dataset=args.dataset,
                                       expand_files=args.query_type,

--- a/fast_curator/catalogues/__init__.py
+++ b/fast_curator/catalogues/__init__.py
@@ -68,7 +68,8 @@ def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True, list_br
     branches = {}
     if list_branches:
         for tree in tree_names:
-            all_branches = (uproot.open(f)[tree].keys(recursive=True) for f in files)
+            open_files = (uproot.open(f) for f in files)
+            all_branches = (f[tree].keys(recursive=True) for f in open_files if tree in f)
             branches[tree] = dict(Counter(sum(all_branches, [])))
 
     if len(n_entries) == 1:

--- a/fast_curator/catalogues/__init__.py
+++ b/fast_curator/catalogues/__init__.py
@@ -1,4 +1,5 @@
 import uproot
+from collections import defaultdict
 
 
 class XrootdExpander():
@@ -39,28 +40,34 @@ class LocalGlobExpander():
         return check_entries_uproot(*args, **kwargs)
 
 
-def check_entries_uproot(files, tree, no_empty, confirm_tree=True):
+def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True):
     no_empty = no_empty or confirm_tree
+    if not isinstance(tree_names, (tuple, list)):
+        tree_names = [tree_names]
+
     if not no_empty:
-        return files, uproot.numentries(files, tree)
+        n_entries = {tree: uproot.numentries(files, tree) for tree in tree_names}
+    else:
+        n_entries = {tree: 0 for tree in tree_names}
+        missing_trees = defaultdict(list)
+        for tree in tree_names:
+            totals = uproot.numentries(files, tree, total=False)
+            for name, entries in totals.items():
+                n_entries[tree] += entries
+                if no_empty and entries <= 0:
+                    files.remove(name)
+                if confirm_tree and entries == 0:
+                    if tree not in uproot.open(name):
+                        missing_trees[tree].append(name)
+        if missing_trees:
+            files = set(sum((list(v) for v in missing_trees.values()), []))
+            msg = "Missing at least one tree (%s) for %d file(s): %s"
+            msg = msg % (", ".join(missing_trees), len(missing_trees), ", ".join(files))
+            raise RuntimeError(msg)
 
-    totals = uproot.numentries(files, tree, total=False)
-    n_entries = 0
-    full_list = []
-    missing_trees = []
-    for name, entries in totals.items():
-        n_entries += entries
-        if not no_empty or entries > 0:
-            full_list.append(name)
-        if confirm_tree and entries == 0:
-            if tree not in uproot.open(name):
-                missing_trees.append(name)
-    if missing_trees:
-        msg = "Tree '%s' wasn't found for %d file(s): %s"
-        msg = msg % (tree, len(missing_trees), ", ".join(missing_trees))
-        raise RuntimeError(msg)
-
-    return full_list, n_entries
+    if len(n_entries) == 1:
+        n_entries = list(n_entries.values())[0]
+    return files, n_entries, branches
 
 
 known_expanders = dict(xrootd=XrootdExpander,

--- a/fast_curator/catalogues/__init__.py
+++ b/fast_curator/catalogues/__init__.py
@@ -1,5 +1,5 @@
 import uproot
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 
 class XrootdExpander():
@@ -17,7 +17,7 @@ class XrootdExpander():
         return full_list
 
     @staticmethod
-    def check_entries(*args, **kwargs):
+    def check_files(*args, **kwargs):
         return check_entries_uproot(*args, **kwargs)
 
 
@@ -36,11 +36,11 @@ class LocalGlobExpander():
         return full_list
 
     @staticmethod
-    def check_entries(*args, **kwargs):
+    def check_files(*args, **kwargs):
         return check_entries_uproot(*args, **kwargs)
 
 
-def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True):
+def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True, list_branches=False):
     no_empty = no_empty or confirm_tree
     if not isinstance(tree_names, (tuple, list)):
         tree_names = [tree_names]
@@ -64,6 +64,12 @@ def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True):
             msg = "Missing at least one tree (%s) for %d file(s): %s"
             msg = msg % (", ".join(missing_trees), len(missing_trees), ", ".join(files))
             raise RuntimeError(msg)
+
+    branches = {}
+    if list_branches:
+        for tree in tree_names:
+            all_branches = (uproot.open(f)[tree].keys(recursive=True) for f in files)
+            branches[tree] = dict(Counter(sum(all_branches, [])))
 
     if len(n_entries) == 1:
         n_entries = list(n_entries.values())[0]

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -15,7 +15,8 @@ __all__ = ["known_expanders", "prepare_file_list", "write_yaml",
 
 
 def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd",
-                      absolute_paths=True, no_empty_files=True, confirm_tree=True):
+                      absolute_paths=True, no_empty_files=True, confirm_tree=True,
+                      include_branches=False):
     """
     Expands all globs in the file lists and creates a dataframe similar to those from a DAS query
     """
@@ -29,6 +30,7 @@ def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd
         full_list = [os.path.realpath(f) if ':' not in f else f for f in full_list]
     full_list, numentries, branches = expand_files.check_files(full_list, tree_name,
                                                                no_empty=no_empty_files,
+                                                               list_branches=include_branches,
                                                                confirm_tree=confirm_tree)
 
     data = {}

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -27,9 +27,9 @@ def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd
     full_list = expand_files.expand_file_list(files)
     if absolute_paths:
         full_list = [os.path.realpath(f) if ':' not in f else f for f in full_list]
-    full_list, numentries = expand_files.check_entries(full_list, tree_name,
-                                                       no_empty=no_empty_files,
-                                                       confirm_tree=confirm_tree)
+    full_list, numentries, branches = expand_files.check_files(full_list, tree_name,
+                                                               no_empty=no_empty_files,
+                                                               confirm_tree=confirm_tree)
 
     data = {}
     data["eventtype"] = eventtype
@@ -38,6 +38,8 @@ def prepare_file_list(files, dataset, eventtype, tree_name, expand_files="xrootd
     data["nfiles"] = len(full_list)
     data["files"] = full_list
     data["tree"] = tree_name
+    if branches:
+        data["branches"] = branches
 
     return data
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -78,7 +78,7 @@ def test_prepare_file_list(dummy_file_dir, nfiles, nevents, empty, expand):
     assert file_list["nevents"] == nevents
     assert len(file_list["branches"]) == 1
     assert len(file_list["branches"]["events"]) == 1
-    assert file_list["branches"]["events"]["ev"] == 1
+    assert file_list["branches"]["events"][b"ev"] == 1
 
 
 @pytest.mark.parametrize("expand", ["xrootd", "local"])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -87,7 +87,7 @@ def test_prepare_file_list_confirm_trees(dummy_file_dir, empty, expand):
                                    expand_files=expand,
                                    confirm_tree=True,
                                    no_empty_files=empty)
-    assert "'events' wasn't found" in str(e)
+    assert "Missing" in str(e) and "events" in str(e)
 
 
 def test_get_file_list_expander():

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -68,6 +68,7 @@ def test_prepare_file_list(dummy_file_dir, nfiles, nevents, empty, expand):
     file_list = fc_write.prepare_file_list(files, "data", "mc", tree_name=tree,
                                            expand_files=expand,
                                            confirm_tree=False,
+                                           include_branches=True,
                                            no_empty_files=empty)
 
     assert isinstance(file_list, dict)
@@ -75,6 +76,9 @@ def test_prepare_file_list(dummy_file_dir, nfiles, nevents, empty, expand):
     assert file_list["eventtype"] == "mc"
     assert file_list["nfiles"] == nfiles
     assert file_list["nevents"] == nevents
+    assert len(file_list["branches"]) == 1
+    assert len(file_list["branches"]["events"]) == 1
+    assert file_list["branches"]["events"]["ev"] == 1
 
 
 @pytest.mark.parametrize("expand", ["xrootd", "local"])


### PR DESCRIPTION
This allows the writing of config files to check and store meta-data for multiple trees per file.