### PR TITLE
Adding option to disable default block in output

### DIFF
--- a/fast_curator/__main__.py
+++ b/fast_curator/__main__.py
@@ -35,6 +35,10 @@ def arg_parser_write():
                         )
     parser.add_argument("-p", "--prefix", default=None,
                         help="Provide a common prefix to files, useful for supporting multiple sites")
+    parser.add_argument("--no-defaults-in-output", dest="no_defaults_in_output",
+                        action="store_true", default=False,
+                        help="Explicitly list all settings for each dataset in output"
+                             " file instead of grouping them in default block")
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
     def split_meta(arg):
@@ -66,7 +70,7 @@ def main_write(args=None):
     for user_func in args.user:
         write.process_user_function(dataset, user_func)
 
-    write.write_yaml(dataset, args.output)
+    write.write_yaml(dataset, args.output, no_defaults_in_output=args.no_defaults_in_output)
 
 
 def arg_parser_check():

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -60,12 +60,16 @@ def select_default(values):
     return most_common
 
 
-def prepare_contents(datasets):
+def prepare_contents(datasets, no_defaults_in_output=False):
     datasets = [vars(data) if isinstance(data, read.Dataset)
                 else data for data in datasets]
     for d in datasets:
         if "associates" in d:
             del d["associates"]
+
+    if no_defaults_in_output:
+        # do not group common settings together in default block
+        return dict(datasets=datasets)
 
     # build the default properties
     values = defaultdict(list)
@@ -99,12 +103,12 @@ def prepare_contents(datasets):
     return contents
 
 
-def write_yaml(dataset, out_file, append=True):
+def write_yaml(dataset, out_file, append=True, no_defaults_in_output=False):
     import yaml
     if os.path.exists(out_file) and append:
         datasets = read.from_yaml(out_file, expand_prefix=False)
         datasets.append(dataset)
-        contents = prepare_contents(datasets)
+        contents = prepare_contents(datasets, no_defaults_in_output=no_defaults_in_output)
     else:
         contents = {}
         contents["datasets"] = [dataset]

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -117,6 +117,9 @@ def write_yaml(dataset, out_file, append=True, no_defaults_in_output=False):
     class MyDumper(yaml.Dumper):
         def increase_indent(self, flow=False, indentless=False):
             return super(MyDumper, self).increase_indent(flow, False)
+        # disable aliases and anchors, see https://github.com/yaml/pyyaml/issues/103
+        def ignore_aliases(self, data):
+            return True
 
     yaml_contents = yaml.dump(
         contents, Dumper=MyDumper, default_flow_style=False)

--- a/fast_curator/write.py
+++ b/fast_curator/write.py
@@ -117,6 +117,7 @@ def write_yaml(dataset, out_file, append=True, no_defaults_in_output=False):
     class MyDumper(yaml.Dumper):
         def increase_indent(self, flow=False, indentless=False):
             return super(MyDumper, self).increase_indent(flow, False)
+
         # disable aliases and anchors, see https://github.com/yaml/pyyaml/issues/103
         def ignore_aliases(self, data):
             return True


### PR DESCRIPTION
This adds a new command line option `--no-defaults-in-output`, which prevents the grouping of common settings into the default block in the output file. Instead, all settings are explicitly listed for every dataset. This addresses issue #38.