### PR TITLE
Updating fast-curator to uproot4

### DIFF
--- a/fast_curator/catalogues/common.py
+++ b/fast_curator/catalogues/common.py
@@ -8,6 +8,12 @@ if sys.version[0] > '2':
 else:
     from urlparse import urlparse
 
+try:
+    uproot_numentries = uproot.numentries  # uproot3
+except AttributeError:
+    import uproot3
+    uproot_numentries = uproot3.numentries
+
 
 class XrootdExpander():
     """
@@ -72,12 +78,12 @@ def check_entries_uproot(files, tree_names, no_empty, confirm_tree=True, list_br
         files = [f for f in files if os.access(f, os.R_OK)]
 
     if not no_empty:
-        n_entries = {tree: uproot.numentries(files, tree) for tree in tree_names}
+        n_entries = {tree: uproot_numentries(files, tree) for tree in tree_names}
     else:
         n_entries = {tree: 0 for tree in tree_names}
         missing_trees = defaultdict(list)
         for tree in tree_names:
-            totals = uproot.numentries(files, tree, total=False)
+            totals = uproot_numentries(files, tree, total=False)
             for name, entries in totals.items():
                 n_entries[tree] += entries
                 if no_empty and entries <= 0:

--- a/fast_curator/read.py
+++ b/fast_curator/read.py
@@ -27,7 +27,7 @@ def associate_by_ext_suffix(datasets):
 def _load_yaml(path):
     import yaml
     with open(path, 'r') as f:
-        datasets_dict = yaml.safe_load(f)
+        datasets_dict = yaml.load(f, Loader=yaml.SafeLoader)
     if not datasets_dict:
         raise RuntimeError("Empty config file in '%s'" % path)
     return datasets_dict

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_version():
         exec(version_file.read(), _globals)
     return _globals["__version__"]
 
-requirements = ['pyyaml', 'six', 'uproot>=4.0.0', 'uproot3']
+requirements = ['pyyaml', 'six', 'uproot>=4.0.7', 'uproot3']
 repositories = []
 
 setup_requirements = ['pytest-runner', ]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_version():
         exec(version_file.read(), _globals)
     return _globals["__version__"]
 
-requirements = ['pyyaml', 'six', 'uproot']
+requirements = ['pyyaml', 'six', 'uproot>=4.0.0', 'uproot3']
 repositories = []
 
 setup_requirements = ['pytest-runner', ]

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -34,6 +34,21 @@ def yaml_config_2(yaml_config_1, tmpdir):
     return str(tmpfile)
 
 
+@pytest.fixture
+def yaml_config_3(tmpdir):
+    content = """
+    datasets:
+      - name: one
+        eventtype: mc
+        files: ["{prefix}one", "two"]
+        prefix: SOME_prefix/
+        nevents: !!int '77729'
+    """
+    tmpfile = tmpdir / "curator_yaml_config_3.yml"
+    tmpfile.write(content)
+    return str(tmpfile)
+
+
 def test_from_yaml_1(yaml_config_1):
     datasets = fc_read.from_yaml(yaml_config_1)
     assert len(datasets) == 1
@@ -42,6 +57,11 @@ def test_from_yaml_1(yaml_config_1):
 def test_from_yaml_2(yaml_config_2):
     datasets = fc_read.from_yaml(yaml_config_2)
     assert len(datasets) == 2
+
+
+def test_from_yaml_3(yaml_config_3):
+    datasets = fc_read.from_yaml(yaml_config_3)
+    assert len(datasets) == 1
 
 
 def test__from_string():

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -84,7 +84,7 @@ def test_prepare_file_list(dummy_file_dir, nfiles, nevents, empty, expand, prefi
     assert file_list["nevents"] == nevents
     assert len(file_list["branches"]) == 1
     assert len(file_list["branches"]["events"]) == 1
-    assert file_list["branches"]["events"][b"ev"] == 1
+    assert file_list["branches"]["events"]["ev"] == 1
     assert any("events_202" in f for f in file_list["files"])
 
 


### PR DESCRIPTION
- numentries taken from `uproot3`
- min `uproot4` version is [4.0.7](https://github.com/scikit-hep/uproot4/releases/tag/4.0.7) to pass all tests (issues with `no-tree.root` otherwise)
- YAML now uses `SafeLoader` by default